### PR TITLE
refactor: logs

### DIFF
--- a/src/logs.ts
+++ b/src/logs.ts
@@ -31,7 +31,7 @@ const publicClient = createPublicClient({
     })
     const logs = await publicClient.getFilterLogs({ filter });
     
-    console.log('args', logs[0].args)
+    console.log('decoded topics (args)', logs[0].args)
 
 
     console.groupEnd();

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -22,25 +22,17 @@ const publicClient = createPublicClient({
     const blockNumber = await publicClient.getBlockNumber();
     console.log({ blockNumber });
 
-    // Read logs from contract
-    const logs = await publicClient.getLogs({
+    const filter = await publicClient.createContractEventFilter({
         ...GreeterContract,
         address: `${process.env.CONTRACT_ADDRESS}` as `0x${string}`,
-        // Retrieve specific log event object
-        event: GreeterContract.abi.find((func) => func.type === "event" && func.name === "NewGreeting"),
-        // adjust fromBlock as needed
+        eventName: 'NewGreeting',
         fromBlock: blockNumber - 100n,
         toBlock: blockNumber,
-    } as GetLogsParameters);
-    console.log({ logs });
+    })
+    const logs = await publicClient.getFilterLogs({ filter });
+    
+    console.log('args', logs[0].args)
 
-    // Decode first log from array retrieved
-    const topics = decodeEventLog({
-        abi: GreeterContract.abi,
-        topics: logs?.[0]?.topics,
-        data: `${logs?.[0]?.data.toString()}` as `0x${string}`
-    });
-    console.log({ topics });
 
     console.groupEnd();
 })();


### PR DESCRIPTION
We can further refactor the logs implementation by:

- Using `createContractEventFilter` instead of raw `getLogs` – this has first class support for contracts (so you don't have to filter out the event ABI item)
- Removed `decodeEventLog` – if you pass a contract filter to `getFilterLogs`, it'll automatically decode it for you ;)